### PR TITLE
Support cache expiration

### DIFF
--- a/MemoryCache.xcodeproj/project.pbxproj
+++ b/MemoryCache.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		980106D6221D3F4F00A8FDBB /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 980106D5221D3F4F00A8FDBB /* Quick.framework */; };
 		980106DA221D612C00A8FDBB /* AnyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980106D9221D612C00A8FDBB /* AnyCache.swift */; };
 		980106E1221F9BD200A8FDBB /* Animals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980106DF221F9BC400A8FDBB /* Animals.swift */; };
+		9801072D222CD10A00A8FDBB /* Expiration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9801072C222CD10A00A8FDBB /* Expiration.swift */; };
+		9801072F222CF52800A8FDBB /* MemoryCacheError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9801072E222CF52800A8FDBB /* MemoryCacheError.swift */; };
+		98010732222CFCFE00A8FDBB /* MemoryCacheError+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98010730222CFCE100A8FDBB /* MemoryCacheError+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,6 +43,9 @@
 		980106D7221D437B00A8FDBB /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		980106D9221D612C00A8FDBB /* AnyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCache.swift; sourceTree = "<group>"; };
 		980106DF221F9BC400A8FDBB /* Animals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animals.swift; sourceTree = "<group>"; };
+		9801072C222CD10A00A8FDBB /* Expiration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expiration.swift; sourceTree = "<group>"; };
+		9801072E222CF52800A8FDBB /* MemoryCacheError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryCacheError.swift; sourceTree = "<group>"; };
+		98010730222CFCE100A8FDBB /* MemoryCacheError+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemoryCacheError+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +96,8 @@
 				980106B9221C172B00A8FDBB /* Info.plist */,
 				980106B8221C172B00A8FDBB /* MemoryCache.h */,
 				980106CF221D3C3600A8FDBB /* MemoryCache.swift */,
+				9801072E222CF52800A8FDBB /* MemoryCacheError.swift */,
+				9801072C222CD10A00A8FDBB /* Expiration.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -100,6 +108,7 @@
 				980106DF221F9BC400A8FDBB /* Animals.swift */,
 				980106C5221C172B00A8FDBB /* Info.plist */,
 				980106C3221C172B00A8FDBB /* MemoryCacheSpecs.swift */,
+				98010730222CFCE100A8FDBB /* MemoryCacheError+.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -245,7 +254,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9801072F222CF52800A8FDBB /* MemoryCacheError.swift in Sources */,
 				980106D0221D3C3600A8FDBB /* MemoryCache.swift in Sources */,
+				9801072D222CD10A00A8FDBB /* Expiration.swift in Sources */,
 				980106DA221D612C00A8FDBB /* AnyCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -256,6 +267,7 @@
 			files = (
 				980106C4221C172B00A8FDBB /* MemoryCacheSpecs.swift in Sources */,
 				980106E1221F9BD200A8FDBB /* Animals.swift in Sources */,
+				98010732222CFCFE00A8FDBB /* MemoryCacheError+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 ## Overview
 MemoryCache is type-safe memory cache. It can benefit from [`NSCache`](https://developer.apple.com/documentation/foundation/nscache) features by wrapping `NSCache` .
 
-```
+```swift
 let memoryCache = MemoryCache(name: "dog")
 
 // Set dog in memoryCache.
 memoryCache.set(dog, for: .dog)
 
 // Load dog in memoryCache.
-let cachedDog: Dog? = memoryCache.load(for: .dog)
+let cachedDog = try memoryCache.load(for: .dog)
 
 // Remove dog in memoryCache.
 memoryCache.remove(for: .dog)
@@ -24,38 +24,42 @@ memoryCache.remove(for: .dog)
 ## Usage
 ### Basic
 ####  Define keys
-
-```
+```swift
 extension MemoryCache.KeyType {
     static let dog = MemoryCache.Key<Dog>(rawValue: "dog")
 }
 ```
 
 #### Set caches
-```
+```swift
 MemoryCache.default.set(dog, for: .dog)
 ```
 
 #### Load caches
-```
-let dog = MemoryCache.default.load(for: .dog)
+```swift
+let dog = try MemoryCache.default.load(for: .dog)
 ```
 
 #### Remove caches
-- Removes the cache of the specified key
-```
+- Removes the cache of the specified key.
+```swift
 MemoryCache.default.remove(for: .dog)
 ```
 
-- Removes All 
+- Removes the cache of the specified key if it expired.
+```swift
+MemoryCache.default.removeIfExpired(for: .dog)
 ```
+
+- Removes All. 
+```swift
 MemoryCache.default.removeAll()
 ```
 
 ### Others
 #### Properties
-```
-/// The maximum total cost that the memoryCache can hold before it starts evicting caches
+```swift
+/// The maximum total cost that the memoryCache can hold before it starts evicting caches.
 var totalCostLimit: Int
 
 /// The maximum number of caches the memoryCache should hold.
@@ -67,7 +71,7 @@ var evictsCachesWithDiscardedContent: Bool
 
 #### Implement delegate
 
-```
+```swift
 import MemoryCache
 
 class SomeClass: NSObject, MemoryCacheDelegate {
@@ -83,6 +87,24 @@ class SomeClass: NSObject, MemoryCacheDelegate {
         // Called when an cache is about to be evicted or removed from the memoryCache.
     }
 }
+```
+
+#### Expiration date
+You can specify expiration date for cache. The default expiration is `.never`.
+
+```swift
+
+/// The expiration date is `.never`.
+memoryCache.set(dog, for: .dog, expiration: .never)
+
+/// The expiration date is `.seconds("""10s""")`.
+memoryCache.set(dog, for: .dog, expiration: .seconds(10))
+
+/// The expiration date is `.date("""TOMORROW""")`.
+memoryCache.set(dog, for: .dog, expiration: .date(Date().addingTimeInterval(60 * 60 * 24)))
+
+/// Remove the cache of the specified key if it expired.
+memoryCache.removeIfExpired(for: .dog)
 ```
 
 ## Requirements
@@ -111,7 +133,7 @@ github "yysskk/MemoryCache"
 and run `carthage update`
 
 ## To do
-- [ ] expiration date of cache
+- [x] expiration date of cache
 - [ ] LRU
 
 ## Author

--- a/Sources/AnyCache.swift
+++ b/Sources/AnyCache.swift
@@ -5,14 +5,16 @@
 //  Created by Yusuke Morishita on 2019/02/19.
 //
 
-final class AnyCache: NSObject, RawRepresentable {
-    typealias RawValue = Any
+final class AnyCache: NSObject {
 
+    let value: Any
+    let expiration: Expiration
 
-    let rawValue: RawValue
+    init(value: Any,
+         expiration: Expiration) {
 
-    init(rawValue: RawValue) {
-        self.rawValue = rawValue
+        self.value = value
+        self.expiration = expiration
     }
 
 }

--- a/Sources/Expiration.swift
+++ b/Sources/Expiration.swift
@@ -1,0 +1,29 @@
+//
+//  Expiration.swift
+//  MemoryCache
+//
+//  Created by Yusuke Morishita on 2019/03/04.
+//
+
+import Foundation
+
+public enum Expiration {
+    case never
+    case seconds(TimeInterval)
+    case date(Date)
+
+    public var date: Date {
+        switch self {
+        case .never:
+            return Date(timeIntervalSince1970: TimeInterval.greatestFiniteMagnitude)
+        case .seconds(let seconds):
+            return Date().addingTimeInterval(seconds)
+        case .date(let date):
+            return date
+        }
+    }
+
+    public var isExpired: Bool {
+        return date.timeIntervalSinceNow < 0
+    }
+}

--- a/Sources/MemoryCacheError.swift
+++ b/Sources/MemoryCacheError.swift
@@ -1,0 +1,14 @@
+//
+//  MemoryCacheError.swift
+//  MemoryCache
+//
+//  Created by Yusuke Morishita on 2019/03/04.
+//
+
+import Foundation
+
+public enum MemoryCacheError: Error {
+    case notFound
+    case unexpectedObject(Any)
+    case expired(Date)
+}

--- a/Tests/MemoryCacheError+.swift
+++ b/Tests/MemoryCacheError+.swift
@@ -1,0 +1,22 @@
+//
+//  MemoryCacheError+.swift
+//  MemoryCache
+//
+//  Created by Yusuke Morishita on 2019/03/04.
+//
+
+import Foundation
+import MemoryCache
+
+extension MemoryCacheError: Equatable {
+    public static func == (lhs: MemoryCacheError, rhs: MemoryCacheError) -> Bool {
+        switch (lhs, rhs) {
+        case (.notFound, .notFound):
+            return true
+        case (.expired(let lDate), .expired(let rDate)):
+            return lDate == rDate
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/MemoryCacheSpecs.swift
+++ b/Tests/MemoryCacheSpecs.swift
@@ -44,17 +44,66 @@ final class MemoryCacheSpec: QuickSpec {
         }
 
         describe("load") {
-            beforeEach {
-                memoryCache.removeAll()
-                memoryCache.set(dog, for: .dog)
+            context("normal") {
+                beforeEach {
+                    memoryCache.removeAll()
+                    memoryCache.set(dog, for: .dog)
+                }
+
+                it("should be dog") {
+                    do {
+                        let cache = try memoryCache.load(for: .dog)
+                        expect(cache.value.name).to(be(dog.name))
+                    } catch {
+                        fail("Catch \(error.localizedDescription)")
+                    }
+                }
             }
 
-            it("should be dog") {
-                do {
-                    let cache = try memoryCache.load(for: .dog)
-                    expect(cache.value.name).to(be(dog.name))
-                } catch {
-                    fail("Catch \(error.localizedDescription)")
+            context("notFound") {
+                beforeEach {
+                    memoryCache.removeAll()
+                }
+
+                it("should catch MemoryCacheError.expired.notFound error") {
+                    do {
+                        let cache = try memoryCache.load(for: .dog)
+                        fail("Catch \(cache.value)")
+                    } catch {
+                        guard let memoryCacheError = error as? MemoryCacheError else {
+                            fail("it doesn't match \(MemoryCacheError.self) type")
+                            return
+                        }
+                        expect(memoryCacheError == .notFound).to(beTrue())
+                    }
+                }
+            }
+
+            context("expired") {
+                var expiration: Expiration!
+
+                beforeEach {
+                    memoryCache.removeAll()
+                    expiration = .date(Date(timeIntervalSinceNow: -60))
+                    memoryCache.set(dog, for: .dog, expiration: expiration)
+                }
+
+                it("should catch MemoryCacheError.expired error") {
+                    do {
+                        let cache = try memoryCache.load(for: .dog)
+                        fail("Catch \(cache.value)")
+                    } catch {
+                        guard let memoryCacheError = error as? MemoryCacheError else {
+                            fail("it doesn't match \(MemoryCacheError.self) type")
+                            return
+                        }
+                        guard case .expired(let date) = memoryCacheError else {
+                            fail("it isn't .expired")
+                            return
+                        }
+
+                        expect(date.timeIntervalSinceReferenceDate == expiration?.date.timeIntervalSinceReferenceDate).to(beTrue())
+                    }
                 }
             }
         }
@@ -67,25 +116,63 @@ final class MemoryCacheSpec: QuickSpec {
                 memoryCache.remove(for: .dog)
             }
 
-            it("should be nil") {
-                do {
-                    let cache = try memoryCache.load(for: .dog)
-                    fail("Catch \(cache.value)")
-                } catch {
-                    guard let memoryCacheError = error as? MemoryCacheError else {
-                        fail("it not match \(MemoryCacheError.self) type")
-                        return
+            context("normal") {
+                beforeEach {
+                    memoryCache.removeAll()
+                    memoryCache.set(dog, for: .dog)
+                }
+
+                it("should be dog") {
+                    do {
+                        let cache = try memoryCache.load(for: .dog)
+                        expect(cache.value.name).to(be(dog.name))
+                    } catch {
+                        fail("Catch \(error.localizedDescription)")
                     }
-                    expect(memoryCacheError == .notFound).to(beTrue())
+                }
+            }
+        }
+
+        describe("removeIfExpired") {
+            var expiration: Expiration!
+
+            context("normal") {
+                beforeEach {
+                    memoryCache.removeAll()
+                    expiration = .date(Date(timeIntervalSinceNow: 60 * 60))
+                    memoryCache.set(dog, for: .dog, expiration: expiration)
+                    memoryCache.removeIfExpired(for: .dog)
+                }
+
+                it("should be dog") {
+                    do {
+                        let cache = try memoryCache.load(for: .dog)
+                        expect(cache.value.name).to(be(dog.name))
+                    } catch {
+                        fail("Catch \(error.localizedDescription)")
+                    }
                 }
             }
 
-            it("should not be nil") {
-                do {
-                    let cache = try memoryCache.load(for: .cat)
-                    expect(cache.value.name).to(be(cat.name))
-                } catch {
-                    fail("Catch \(error.localizedDescription)")
+            context("If the cache expired") {
+                beforeEach {
+                    memoryCache.removeAll()
+                    expiration = .date(Date(timeIntervalSinceNow: -60))
+                    memoryCache.set(dog, for: .dog, expiration: expiration)
+                    memoryCache.removeIfExpired(for: .dog)
+                }
+
+                it("should catch MemoryCacheError.notFound error") {
+                    do {
+                        let cache = try memoryCache.load(for: .dog)
+                        fail("Catch \(cache.value)")
+                    } catch {
+                        guard let memoryCacheError = error as? MemoryCacheError else {
+                            fail("it doesn't match \(MemoryCacheError.self) type")
+                            return
+                        }
+                        expect(memoryCacheError == .notFound).to(beTrue())
+                    }
                 }
             }
         }
@@ -98,13 +185,13 @@ final class MemoryCacheSpec: QuickSpec {
                 memoryCache.removeAll()
             }
 
-            it("should be nil") {
+            it("should catch MemoryCacheError.notFound error") {
                 do {
                     let cache = try memoryCache.load(for: .dog)
                     fail("Catch \(cache.value)")
                 } catch {
                     guard let memoryCacheError = error as? MemoryCacheError else {
-                        fail("it not match \(MemoryCacheError.self) type")
+                        fail("it doesn't match \(MemoryCacheError.self) type")
                         return
                     }
                     expect(memoryCacheError == .notFound).to(beTrue())
@@ -115,10 +202,121 @@ final class MemoryCacheSpec: QuickSpec {
                     fail("Catch \(cache.value)")
                 } catch {
                     guard let memoryCacheError = error as? MemoryCacheError else {
-                        fail("it not match \(MemoryCacheError.self) type")
+                        fail("it doesn't match \(MemoryCacheError.self) type")
                         return
                     }
                     expect(memoryCacheError == .notFound).to(beTrue())
+                }
+            }
+        }
+
+        describe("Expiration") {
+            var expiration: Expiration!
+
+            context(".never") {
+                beforeEach {
+                    memoryCache.removeAll()
+                    expiration = .never
+                    memoryCache.set(dog, for: .dog, expiration: expiration)
+                }
+
+                it("should be dog") {
+                    do {
+                        let cache = try memoryCache.load(for: .dog)
+                        expect(cache.value.name).to(be(dog.name))
+                    } catch {
+                        fail("Catch \(error.localizedDescription)")
+                    }
+                }
+            }
+
+            context(".seconds") {
+                context("normal") {
+                    beforeEach {
+                        memoryCache.removeAll()
+                        expiration = .seconds(60 * 60)
+                        memoryCache.set(dog, for: .dog, expiration: expiration)
+                    }
+
+                    it("should be dog") {
+                        do {
+                            let cache = try memoryCache.load(for: .dog)
+                            expect(cache.value.name).to(be(dog.name))
+                        } catch {
+                            fail("Catch \(error.localizedDescription)")
+                        }
+                    }
+                }
+
+                context("If the cache expired") {
+                    beforeEach {
+                        memoryCache.removeAll()
+                        expiration = .seconds(-60)
+                        memoryCache.set(dog, for: .dog, expiration: expiration)
+                    }
+
+                    it("should catch MemoryCacheError.expired error") {
+                        do {
+                            let cache = try memoryCache.load(for: .dog)
+                            fail("Catch \(cache.value)")
+                        } catch {
+                            guard let memoryCacheError = error as? MemoryCacheError else {
+                                fail("it doesn't match \(MemoryCacheError.self) type")
+                                return
+                            }
+                            guard case .expired(let date) = memoryCacheError else {
+                                fail("it isn't .expired")
+                                return
+                            }
+
+                            expect(date < Date().addingTimeInterval(-60)).to(beTrue())
+                        }
+                    }
+                }
+            }
+
+            context(".date") {
+                context("normal") {
+                    beforeEach {
+                        memoryCache.removeAll()
+                        expiration = .date(Date(timeIntervalSinceNow: 60 * 60))
+                        memoryCache.set(dog, for: .dog, expiration: expiration)
+                    }
+
+                    it("should be dog") {
+                        do {
+                            let cache = try memoryCache.load(for: .dog)
+                            expect(cache.value.name).to(be(dog.name))
+                        } catch {
+                            fail("Catch \(error.localizedDescription)")
+                        }
+                    }
+                }
+
+                context("If the cache expired") {
+                    beforeEach {
+                        memoryCache.removeAll()
+                        expiration = .date(Date(timeIntervalSinceNow: -60))
+                        memoryCache.set(dog, for: .dog, expiration: expiration)
+                    }
+
+                    it("should catch MemoryCacheError.expired error") {
+                        do {
+                            let cache = try memoryCache.load(for: .dog)
+                            fail("Catch \(cache.value)")
+                        } catch {
+                            guard let memoryCacheError = error as? MemoryCacheError else {
+                                fail("it doesn't match \(MemoryCacheError.self) type")
+                                return
+                            }
+                            guard case .expired(let date) = memoryCacheError else {
+                                fail("it isn't .expired")
+                                return
+                            }
+
+                            expect(date.timeIntervalSinceReferenceDate == expiration?.date.timeIntervalSinceReferenceDate).to(beTrue())
+                        }
+                    }
                 }
             }
         }

--- a/Tests/MemoryCacheSpecs.swift
+++ b/Tests/MemoryCacheSpecs.swift
@@ -34,7 +34,12 @@ final class MemoryCacheSpec: QuickSpec {
             }
 
             it("should be dog") {
-                expect(memoryCache.load(for: .dog)?.name).to(be(dog.name))
+                do {
+                    let cache = try memoryCache.load(for: .dog)
+                    expect(cache.value.name).to(be(dog.name))
+                } catch {
+                    fail("Catch \(error.localizedDescription)")
+                }
             }
         }
 
@@ -45,7 +50,12 @@ final class MemoryCacheSpec: QuickSpec {
             }
 
             it("should be dog") {
-                expect(memoryCache.load(for: .dog)?.name).to(be(dog.name))
+                do {
+                    let cache = try memoryCache.load(for: .dog)
+                    expect(cache.value.name).to(be(dog.name))
+                } catch {
+                    fail("Catch \(error.localizedDescription)")
+                }
             }
         }
 
@@ -58,11 +68,25 @@ final class MemoryCacheSpec: QuickSpec {
             }
 
             it("should be nil") {
-                expect(memoryCache.load(for: .dog)).to(beNil())
+                do {
+                    let cache = try memoryCache.load(for: .dog)
+                    fail("Catch \(cache.value)")
+                } catch {
+                    guard let memoryCacheError = error as? MemoryCacheError else {
+                        fail("it not match \(MemoryCacheError.self) type")
+                        return
+                    }
+                    expect(memoryCacheError == .notFound).to(beTrue())
+                }
             }
 
             it("should not be nil") {
-                expect(memoryCache.load(for: .cat)).notTo(beNil())
+                do {
+                    let cache = try memoryCache.load(for: .cat)
+                    expect(cache.value.name).to(be(cat.name))
+                } catch {
+                    fail("Catch \(error.localizedDescription)")
+                }
             }
         }
 
@@ -75,8 +99,27 @@ final class MemoryCacheSpec: QuickSpec {
             }
 
             it("should be nil") {
-                expect(memoryCache.load(for: .dog)).to(beNil())
-                expect(memoryCache.load(for: .cat)).to(beNil())
+                do {
+                    let cache = try memoryCache.load(for: .dog)
+                    fail("Catch \(cache.value)")
+                } catch {
+                    guard let memoryCacheError = error as? MemoryCacheError else {
+                        fail("it not match \(MemoryCacheError.self) type")
+                        return
+                    }
+                    expect(memoryCacheError == .notFound).to(beTrue())
+                }
+
+                do {
+                    let cache = try memoryCache.load(for: .cat)
+                    fail("Catch \(cache.value)")
+                } catch {
+                    guard let memoryCacheError = error as? MemoryCacheError else {
+                        fail("it not match \(MemoryCacheError.self) type")
+                        return
+                    }
+                    expect(memoryCacheError == .notFound).to(beTrue())
+                }
             }
         }
     }


### PR DESCRIPTION
Example codes

```swift
 /// The expiration date is `.never`.
memoryCache.set(dog, for: .dog, expiration: .never)

 /// The expiration date is `.seconds("""10s""")`.
memoryCache.set(dog, for: .dog, expiration: .seconds(10))

 /// The expiration date is `.date("""TOMORROW""")`.
memoryCache.set(dog, for: .dog, expiration: .date(Date().addingTimeInterval(60 * 60 * 24)))

 /// Remove the cache of the specified key if it expired.
memoryCache.removeIfExpired(for: .dog)
```
